### PR TITLE
Minor; make sure Bitcoin and Cash are a name

### DIFF
--- a/src/payButton/PayButton.js
+++ b/src/payButton/PayButton.js
@@ -268,8 +268,8 @@ class PayButton extends Component {
                   marginTop:'-1.5em',
                 }}
               >
-                Send {this.amount == 0 ? 'some' : this.props.amount} Bitcoin
-                Cash (BCH) to this address to complete your payment
+                Send {this.amount == 0 ? 'some' : this.props.amount}
+                Bitcoin&nbsp;Cash (BCH) to this address to complete your payment
               </p>
               <img
                 src={this.QRCodeURL}


### PR DESCRIPTION
Make sure that whatever the width of the screen, the name "Bitcoin Cash" stays one unit and is not split across two lines.

We want to make sure that nobody sends BTC to the merchant because they misunderstood.