### PR TITLE
Made payment modal responsive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ modules/website/public/pay.js.map
 modules/website/public/docs/
 modules/api/public/
 modules/docs/source/index.html.md
+
+# Editor
+.vscode/

--- a/modules/inject/inject.js
+++ b/modules/inject/inject.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import PayButton from '../paybutton/src/PayButton'
+import PayButton from '../paybutton/build/PayButton'
 
 // fail when there is no window object
 if (typeof window !== 'object') {

--- a/modules/inject/package.json
+++ b/modules/inject/package.json
@@ -27,7 +27,8 @@
   },
   "scripts": {
     "build": "rollup --config rollup.prod.js --environment INCLUDE_DEPS,BUILD:production",
-    "dev": "rollup --config rollup.dev.js --watch --environment INCLUDE_DEPS,BUILD:development"
+    "dev": "rollup --config rollup.dev.js --watch --environment INCLUDE_DEPS,BUILD:development",
+    "build-dev": "yarn workspace @gatewaycash/paybutton build && yarn workspace @gatewaycash/inject rollup --config rollup.dev.js --environment INCLUDE_DEPS,BUILD:development"
   },
   "dependencies": {
     "react": "^16.7.0-alpha.2",

--- a/modules/paybutton/package.json
+++ b/modules/paybutton/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-react": "^7.0.0",
     "rollup": "^0.67.3",
     "rollup-plugin-babel": "^4.0.3",
+    "rollup-plugin-includepaths": "^0.2.3",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-replace": "^2.1.0"
   }

--- a/modules/paybutton/rollup.config.js
+++ b/modules/paybutton/rollup.config.js
@@ -1,6 +1,8 @@
 import resolve from 'rollup-plugin-node-resolve'
 import babel from 'rollup-plugin-babel'
 import replace from 'rollup-plugin-replace'
+import includePaths from 'rollup-plugin-includepaths'
+import commonjs from 'rollup-plugin-commonjs'
 
 export default {
   input: 'src/PayButton.js',
@@ -26,22 +28,35 @@ export default {
     resolve({
       preferBuiltins: false
     }),
+    commonjs({ include: '../../node_modules/**' }),
     babel({
-      exclude: ['../../node_modules/**', '*.json'],
+      exclude: '../../node_modules/**',
+      babelrc: false,
       presets: [
         [
           '@babel/env',
           {
             modules: false,
-            targets: '> 0.25%, not dead'
+            targets: {
+              chrome: '58',
+              ie: '11'
+            },
+            useBuiltIns: 'usage'
           }
         ],
         '@babel/preset-react'
       ],
-      babelrc: false
+      plugins: [
+        '@babel/transform-regenerator',
+        '@babel/plugin-external-helpers'
+      ]
     }),
     replace({
       'process.env.NODE_ENV': JSON.stringify('production')
+    }),
+    includePaths({
+      paths: ['src'],
+      extensions: ['.js']
     })
   ]
 }

--- a/modules/paybutton/src/Dialog/PaymentProgress.js
+++ b/modules/paybutton/src/Dialog/PaymentProgress.js
@@ -1,19 +1,23 @@
 import React from 'react'
 import Button from '@material-ui/core/Button'
 import PropTypes from 'prop-types'
+import styles from 'jss/PaymentProgress'
+import withStyles from '@material-ui/core/styles/withStyles'
 
 let PaymentProgress = ({
+  classes,
   amountBCH,
   paymentAddress,
   hideWalletButton,
   hideAddressText
 }) => (
-  <center>
-    <p>
-      Send {amountBCH == 0 ? 'some' : amountBCH} Bitcoin&nbsp;Cash (BCH) to this
-      address to complete your payment
-    </p>
+  <div className={classes.container}>
+    <span>
+      Send {amountBCH || 'some'} Bitcoin&nbsp;Cash (BCH) to this address to
+      complete your payment
+    </span>
     <img
+      className={classes.qrCode}
       src={
         amountBCH > 0
           ? 'https://chart.googleapis.com/chart?chs=300x300&cht=qr&chl=' +
@@ -26,14 +30,6 @@ let PaymentProgress = ({
       alt="Payment QR code"
       title="Payment QR code"
       poster="Payment QR code"
-      style={{
-        width: '15em',
-        margin: 'auto',
-        marginTop: '-1em',
-        marginBottom: '-2em',
-        align: 'center',
-        clip: 'rect(10px,50px,50px,10px)'
-      }}
     />
     {hideAddressText || (
       <p
@@ -51,6 +47,7 @@ let PaymentProgress = ({
     {hideWalletButton || (
       <Button
         variant="contained"
+        className={classes.hideWalletButton}
         color="primary"
         href={
           amountBCH > 0
@@ -61,14 +58,15 @@ let PaymentProgress = ({
         OPEN WALLET
       </Button>
     )}
-  </center>
+  </div>
 )
 
 PaymentProgress.propTypes = {
+  classes: PropTypes.object,
   amountBCH: PropTypes.any.isRequired,
   paymentAddress: PropTypes.string.isRequired,
   hideWalletButton: PropTypes.bool.isRequired,
   hideAddressText: PropTypes.bool.isRequired
 }
 
-export default PaymentProgress
+export default withStyles(styles)(PaymentProgress)

--- a/modules/paybutton/src/Dialog/index.js
+++ b/modules/paybutton/src/Dialog/index.js
@@ -2,8 +2,18 @@ import React from 'react'
 import Dialog from '@material-ui/core/Dialog'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import DialogContent from '@material-ui/core/DialogContent'
+import styles from 'jss/PaymentDialog'
+import withStyles from '@material-ui/core/styles/withStyles'
+import PropTypes from 'prop-types'
 
-export default ({ open, title, onClose, children }) => (
+let PaymentDialog = ({
+  classes,
+  open,
+  title,
+  onClose,
+  children,
+  closeDialog
+}) => (
   <Dialog
     open={open}
     keepMounted
@@ -11,15 +21,34 @@ export default ({ open, title, onClose, children }) => (
     style={{
       fontFamily: 'helvetica'
     }}
+    PaperProps={{
+      classes: {
+        root: classes.container_root
+      }
+    }}
   >
     <DialogTitle
-      style={{
-        marginTop: '-0.7em',
-        marginBottom: '-2em'
-      }}
+      disableTypography={true}
+      classes={{ root: classes.title_wrap__root }}
     >
-      <center>{title}</center>
+      <h2 className={classes.title_wrap}>
+        <span className={classes.title}>{title}</span>
+      </h2>
+      <span className={classes.close} onClick={closeDialog}>
+        X
+      </span>
     </DialogTitle>
-    <DialogContent>{children}</DialogContent>
+    <DialogContent className={classes.content_wrap}>{children}</DialogContent>
   </Dialog>
 )
+
+PaymentDialog.propTypes = {
+  classes: PropTypes.object,
+  open: PropTypes.bool,
+  title: PropTypes.string,
+  onClose: PropTypes.func,
+  children: PropTypes.object,
+  closeDialog: PropTypes.func
+}
+
+export default withStyles(styles)(PaymentDialog)

--- a/modules/paybutton/src/PayButton.js
+++ b/modules/paybutton/src/PayButton.js
@@ -72,10 +72,7 @@ let PayButton = props => {
       .toString()
     // shave off all the exra zeros from the end
     while (calculatedAmount.endsWith('0')) {
-      calculatedAmount = calculatedAmount.substr(
-        0,
-        calculatedAmount.length - 1
-      )
+      calculatedAmount = calculatedAmount.substr(0, calculatedAmount.length - 1)
     }
     setAmountBCH(calculatedAmount)
     amountBCH = calculatedAmount
@@ -97,9 +94,7 @@ let PayButton = props => {
         }
       } catch (e) {
         alert(
-          showError(
-            'We\'re having some trouble contacting the Gateway server!'
-          )
+          showError('We\'re having some trouble contacting the Gateway server!')
         )
         return
       }
@@ -236,9 +231,9 @@ let PayButton = props => {
       </Button>
       <Dialog
         open={dialogOpen}
-        keepMounted
         onClose={handleClose}
         title={paymentComplete ? 'Thank you!' : props.dialogTitle}
+        closeDialog={() => setDialogOpen(false)}
       >
         {paymentComplete ? (
           <PaymentComplete />

--- a/modules/paybutton/src/jss/PaymentDialog.js
+++ b/modules/paybutton/src/jss/PaymentDialog.js
@@ -1,0 +1,36 @@
+export default () => ({
+  title_wrap: {
+    display: 'flex',
+    'flex-direction': 'row',
+    margin: 0,
+    padding: '24px 24px 20px',
+    'flex-basis': '90%'
+  },
+  title_wrap__root: {
+    padding: 0,
+    'border-bottom': '1px gray solid',
+    display: 'flex',
+    'flex-direction': 'row'
+  },
+  title: {
+    'text-align': 'center',
+    'flex-basis': '90%',
+    'margin-left': '7%'
+  },
+  content_wrap: {
+    overflow: 'hidden',
+    padding: '24px',
+    height: '100%'
+  },
+  close: {
+    'margin-top': '2%',
+    cursor: 'pointer',
+    'margin-right': '2%'
+  },
+  container_root: {
+    '@media (max-width: 546px)': {
+      height: '90%',
+      margin: '5%'
+    }
+  }
+})

--- a/modules/paybutton/src/jss/PaymentProgress.js
+++ b/modules/paybutton/src/jss/PaymentProgress.js
@@ -1,0 +1,20 @@
+export default () => ({
+  qrCode: {
+    width: '60%',
+    margin: '0 auto',
+    '@media (max-width: 546px)': {
+      width: '100%'
+    }
+  },
+  hideWalletButton: {
+    width: 'fit-content',
+    margin: '0 auto'
+  },
+  container: {
+    display: 'flex',
+    'flex-direction': 'column',
+    'flex-grow': 1,
+    height: '100%',
+    'text-align': 'center'
+  }
+})

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -12,4 +12,4 @@
 # built side-by-side and must come one after the other.
 
 echo "Starting the build..."
-concurrently "yarn paybutton-docs-build && yarn api-docs-build" "yarn paybutton-build" "yarn inject-build && yarn site-build"
+concurrently "yarn paybutton-docs-build && yarn api-docs-build" "yarn paybutton-build && yarn inject-build && yarn site-build"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8690,6 +8690,10 @@ rollup-plugin-commonjs@^9.2.0:
     resolve "^1.8.1"
     rollup-pluginutils "^2.3.3"
 
+rollup-plugin-includepaths@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-includepaths/-/rollup-plugin-includepaths-0.2.3.tgz#244d21b9669a0debe476d825e4a02ed08c06b258"
+
 rollup-plugin-json@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz#7c1daf60c46bc21021ea016bd00863561a03321b"


### PR DESCRIPTION
* New `build-dev` command in inject module is necessary so that the paybutton src is compiled correctly before being used by `inject.js`.  Paybutton needs to be separately compiled since it needs rollup to run the `includePaths` plugin to resolve relative imports.