### PR TITLE
Allow XPUB in Platforms

### DIFF
--- a/modules/api/SQLSetup.sql
+++ b/modules/api/SQLSetup.sql
@@ -76,7 +76,8 @@ CREATE TABLE IF NOT EXISTS platforms (
   name VARCHAR(36),
   description VARCHAR(160),
   ownerUserIndex VARCHAR(8),
-  totalSales INT(15) DEFAULT 0
+  totalSales INT(15) DEFAULT 0,
+  allowXPUB INT(1) DEFAULT 0
 );
 ALTER TABLE platforms AUTO_INCREMENT = 1;
 

--- a/modules/api/src/endpoints/platforms.js
+++ b/modules/api/src/endpoints/platforms.js
@@ -90,7 +90,7 @@ let PATCH = async (req, res) => {
   if (
     !req.body.newName &&
     !req.body.newDescription &&
-    typeof req.body.newAllowXPUB === undefined
+    typeof req.body.newAllowXPUB === 'undefined'
   ) {
     return handleError(
       'No New Data',
@@ -119,9 +119,11 @@ let PATCH = async (req, res) => {
 
   // validate newAllowXPUB value
   if (
-    typeof req.body.newAllowXPUB !== undefined &&
-    req.body.newAllowXPUB !== 'true' &&
-    req.body.newAllowXPUB !== 'false'
+    typeof req.body.newAllowXPUB !== 'undefined' &&
+    (
+      req.body.newAllowXPUB !== 'true' &&
+      req.body.newAllowXPUB !== 'false'
+    )
   ) {
     return handleError(
       'Allow XPUB Invalid',
@@ -182,6 +184,7 @@ let PATCH = async (req, res) => {
   return handleResponse({
     newName: newName,
     newDescription: newDescription,
+    newAllowXPUB: newAllowXPUB == 1,
     platformID: req.body.platformID
   }, res)
 }

--- a/modules/api/src/endpoints/platforms.js
+++ b/modules/api/src/endpoints/platforms.js
@@ -23,7 +23,8 @@ let GET = async (req, res) => {
       created: '' + platforms[i].created,
       name: platforms[i].name,
       description: platforms[i].description,
-      platformID: platforms[i].platformID
+      platformID: platforms[i].platformID,
+      allowXPUB: platforms[i].allowXPUB == 1
     })
   }
   return handleResponse({
@@ -85,11 +86,15 @@ let PUT = async (req, res) => {
 
 // PATCH an existing platform with new data
 let PATCH = async (req, res) => {
-  // ensure newName or newDescription was given
-  if (!req.body.newName && !req.body.newDescription) {
+  // ensure newName, newDescription or newAllowXPUB was given
+  if (
+    !req.body.newName &&
+    !req.body.newDescription &&
+    typeof req.body.newAllowXPUB === undefined
+  ) {
     return handleError(
       'No New Data',
-      'Provide a new name or description for the platform',
+      'Provide a new name, description or allowXPUB value for the platform',
       res
     )
   }
@@ -108,6 +113,19 @@ let PATCH = async (req, res) => {
     return handleError(
       'Platform Description Too Long',
       'Max length is 160 characters',
+      res
+    )
+  }
+
+  // validate newAllowXPUB value
+  if (
+    typeof req.body.newAllowXPUB !== undefined &&
+    req.body.newAllowXPUB !== 'true' &&
+    req.body.newAllowXPUB !== 'false'
+  ) {
+    return handleError(
+      'Allow XPUB Invalid',
+      'The new value for the "allow XPUB" setting must be either "true" or "false"',
       res
     )
   }
@@ -142,11 +160,22 @@ let PATCH = async (req, res) => {
   // assign the new values
   let newName = req.body.newName || platform.name
   let newDescription = req.body.newDescription || platform.description
+  let newAllowXPUB
+  if (typeof req.body.newAllowXPUB !== undefined) {
+    newAllowXPUB = req.body.newAllowXPUB === 'true' ? 1 : 0
+  } else {
+    newAllowXPUB = platform.newAllowXPUB
+  }
 
   // update the record
   await mysql.query(
-    'UPDATE platforms SET name = ?, description = ? WHERE tableIndex = ?',
-    [newName, newDescription, platform.tableIndex]
+    `UPDATE platforms
+      SET name = ?,
+      description = ?,
+      allowXPUB = ?
+      WHERE
+      tableIndex = ?`,
+    [newName, newDescription, newAllowXPUB, platform.tableIndex]
   )
 
   // send the success message

--- a/modules/api/src/endpoints/user/register.js
+++ b/modules/api/src/endpoints/user/register.js
@@ -31,7 +31,7 @@ let POST = async (req, res) => {
   let addressValid = null
   let XPUBValid = null
   if (req.body.XPUB) {
-    XPUBValid = validateXPUB(req.body.XPUB)
+    XPUBValid = validateXPUB(req.body.XPUB, res)
     if (!XPUBValid) return
   } else {
     addressValid = validateAddress(req.body.address, res)

--- a/modules/docs/docs/api.html.md
+++ b/modules/docs/docs/api.html.md
@@ -177,20 +177,10 @@ It is not possible to utilize Platform commissions if your Platforms user
 accounts have XPUB keys. This is because when XPUB is used, payment is
 forwarded directly to the merchant and Gateway never controls the funds.
 
-To avoid this problem, always send Platforms user registration requests with an
-address only and not an XPUB key. If you are sending Platforms user
-registration requests from the user's browser, be aware of the possibility for
-malicious activity. A user can avoid paying any commissions if they are using
-XPUB.
-
-<b>Strongly consider</b> sending the Platforms user registration requests from
-your server instead. Randomly generate usernames and passwords which are stored
-with your users' login information.
-
 If you do not ever want to take a commission and only want to use Gateway
 Platforms to track total platform sales, you can still use XPUB with Platforms
 user accounts. Include `dismissXPUBWithPlatformIDWarning=YES` with your
-request to bypass the warning. You can also disallow XPUB entirely (see below).
+request to bypass the warning.
 
 <aside class="notice">
 Please provide your Bitcoin Cash address in CashAddress format. If it is given
@@ -199,8 +189,8 @@ database. If we can't understand your address, we can't pay you!
 </aside>
 
 <aside class="notice">
-The API server does not thoroughly evaluate the security or entropy of provided passwords.
-It is the responsibility of the end user and/or the front-end
+The API server does not thoroughly evaluate the security or entropy of provided
+passwords. It is the responsibility of the end user and/or the front-end
 service provider to ensure that a secure password is provided. Passwords
 are always salted and hashed prior to being stored in the database.
 </aside>
@@ -1239,10 +1229,9 @@ owner can set commission rules for the platform and take a percentage of the
 earnings as profit.
 
 <aside class="notice">
-There are future plans for platforms to be owned by multiple accounts who must
-vote and ascent to features. There are also plans for owners to be able to
-designate administrators and managers for platforms who have differing
-permissions and rights to change certain aspects of a platform.
+There are plans for owners to be able to designate administrators and managers
+for platforms who have differing permissions and rights to change certain
+aspects of a platform. These features are under development.
 </aside>
 
 ## Platform Users
@@ -1252,10 +1241,11 @@ Platform users are created in the same manner as normal users. See the
 registration request to create a new Platforms user.
 
 The new user will be exclusively owned by the platform and any payments sent to
-their `merchantID` will be subject to the commissions of the platform.
+their `merchantID` will be subject to the commissions and policies of the
+platform.
 
 <aside class="notice">
-No, Platforms users can not create their own platforms. Nice try :)
+No, Platforms users can't create their own platforms. Nice try :)
 </aside>
 
 ## Creating a Platform
@@ -1347,7 +1337,7 @@ Yes | `APIKey` | An active API key belonging to the account for which a list of 
 
 ## Changing Platform Settings
 
-> Update the platform name and/or description:
+> Update the platform name and settings:
 
 ```js
 let result = await axios.patch(
@@ -1373,7 +1363,7 @@ let result = await axios.patch(
 ```
 
 The PATCH `/platforms` endpoint allows you to specify new settings for a
-platform. Currently, setting a new name and description are supported.
+platform. This is how the policies that govern your platforms are managed.
 
 ### Parameters
 
@@ -1381,15 +1371,9 @@ Required | Name | Description
 ---------|------|------------
 Yes | `APIKey` | An active API key belonging to someone with permission
 Yes | `platformID` | The ID of the platform to be updated
-Sometimes | `newName` | A new name for the platform
-Sometimes | `newDescription` | A new description for the platform
-
-At least one of `newName` and `newDescription` is required.
-
-<aside class="notice">
-There are plans for this endpoint to include support for many other features,
-including permissions management, dis/allowing the use of XPUB keys and more.
-</aside>
+No | `newName` | A new name for the platform
+No | `newDescription` | A new description for the platform
+No | `newAllowXPUB` | Whether XPUB keys are allowed. Either `"true"` or `"false"`.
 
 ## Commission Rules
 


### PR DESCRIPTION
Adds a setting and a warning flag to the Platforms API so that XPUB keys can be enabled or disabled. They are disabled by default.